### PR TITLE
Move to .NET 6 / Ubuntu "Jammy" / docfx 2.60.0-preview.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,10 @@
-FROM mono:latest
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy
 
-RUN apt update -yqq \
-    && apt install -yqq gpg apt-transport-https \
-    && curl -o - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg \
-    && curl -o /etc/apt/sources.list.d/microsoft-prod.list https://packages.microsoft.com/config/debian/9/prod.list \
-    && chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg \
-                       /etc/apt/sources.list.d/microsoft-prod.list \
-    && apt update -yqq \
-    && apt install -yqq \
-        unzip \
-        git \
-        dotnet-sdk-6.0 \
-        wkhtmltopdf \
-    && rm -rf /var/lib/apt/lists/*
+RUN dotnet --version
 
-ENV PATH="/docfx:${PATH}"
+RUN dotnet tool install --global docfx --version 2.60.0-preview.2
+RUN dotnet tool list --global
+
+RUN docfx -v
+
 ENTRYPOINT [ "docfx" ]
-
-ADD ./entrypoint.sh /usr/local/bin/docfx
-
-ADD https://github.com/dotnet/docfx/releases/download/v2.59.4/docfx.zip /
-RUN unzip docfx.zip -d /docfx && \
-    rm docfx.zip
-
-# An attrmpt to avoid "dubious ownership" errors in CI systems
-RUN git config --global --add safe.directory /github/workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy
 
 RUN dotnet --version
 
-RUN dotnet tool install --global docfx --version 2.60.0-preview.2
-RUN dotnet tool list --global
+# Setting the path up to allow .NET tools
+ENV PATH "$PATH:/root/.dotnet/tools"
 
+RUN dotnet tool install --global docfx --version 2.60.0-preview.2
+
+# Just checking things
+RUN dotnet tool list --global
 RUN docfx -v
 
 ENTRYPOINT [ "docfx" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-mono "/docfx/docfx.exe" "$@"


### PR DESCRIPTION
Resolves #14.

I'm excited about this because it feels like a much more straightforward tooling experience, so much so that it will likely obsolete this repo. 

* Moves to the official .NET SDK container for .NET 6 and Ubuntu "Jammy"
* Utilizes docfx's new support as a cross-platform dotnet global tool
 * Which means we don't need to worry about using Mono anymore
 * Which means we can cleanup almost all the lines of our container