### PR TITLE
Update Dockerfile to negate git patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,9 @@ RUN dotnet tool install --global docfx --version 2.60.0-preview.2
 RUN dotnet tool list --global
 RUN docfx -v
 
+# HACK: This effectively negates a git security patch that requires file ownership to match.
+# Doing this because it does not appear that there is a standard way to address this in our container setup.
+# A follow-up will likely be to take in a parameter and set the safe directory when that parameter is passed in.
+RUN git config --global --add safe.directory '*'
+
 ENTRYPOINT [ "docfx" ]


### PR DESCRIPTION
This git patch is security-related, but does not necessarily apply in our scenarios. Not having this in place causes "dubious ownership" errors later on in the process, breaking the entire build chain.