### PR TITLE
Use system-level git config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ RUN docfx -v
 # HACK: This effectively negates a git security patch that requires file ownership to match.
 # Doing this because it does not appear that there is a standard way to address this in our container setup.
 # A follow-up will likely be to take in a parameter and set the safe directory when that parameter is passed in.
-RUN git config --global --add safe.directory '*'
+RUN git config --system --add safe.directory '*'
 
 ENTRYPOINT [ "docfx" ]


### PR DESCRIPTION
A follow-up to #16 , but making the configuration global so that docfx will have access to it as well.