### PR TITLE
Updated .NET SDK to 7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN dotnet --version
 # Setting the path up to allow .NET tools
 ENV PATH "$PATH:/root/.dotnet/tools"
 
-RUN dotnet tool install --global docfx --version 2.70.4
+RUN dotnet tool install --global docfx --version 2.71.0
 
 # Just checking things
 RUN dotnet tool list --global

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN dotnet --version
 # Setting the path up to allow .NET tools
 ENV PATH "$PATH:/root/.dotnet/tools"
 
-RUN dotnet tool install --global docfx --version 2.70.3
+RUN dotnet tool install --global docfx --version 2.70.4
 
 # Just checking things
 RUN dotnet tool list --global

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN dotnet --version
 # Setting the path up to allow .NET tools
 ENV PATH "$PATH:/root/.dotnet/tools"
 
-RUN dotnet tool install --global docfx --version 2.70.1
+RUN dotnet tool install --global docfx --version 2.70.3
 
 # Just checking things
 RUN dotnet tool list --global

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN dotnet --version
 # Setting the path up to allow .NET tools
 ENV PATH "$PATH:/root/.dotnet/tools"
 
-RUN dotnet tool install --global docfx --version 2.67.5
+RUN dotnet tool install --global docfx --version 2.70.0
 
 # Just checking things
 RUN dotnet tool list --global


### PR DESCRIPTION
This pull request will allow docfx-action to use the .NET 7.0 SDK to be able to build applications that are built with .NET 7.0.

Also, this PR updates DocFX to 2.70.3

Tested with Nitrocid KS and got the following results:

- [API Documentation](https://aptivi.github.io/NitrocidKS/api/KS.Arguments.ArgumentBase.html)
- [Job log](https://github.com/Aptivi/NitrocidKS/actions/runs/5916515008/job/16043880598)

Thanks!