### PR TITLE
Allow RenovateBot to manage the docfx version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+    "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": ["docfx --version (?<currentValue>.*?)\\n"],
+      "depNameTemplate": "docfx",
+      "datasourceTemplate": "nuget"
+    }
   ]
 }


### PR DESCRIPTION
Using a [custom manager](https://docs.renovatebot.com/modules/manager/regex/) in RenovateBot, I believe we can look for a match based on regex and have the replacement suggested to us automatically, enabling us to automate the process.